### PR TITLE
[FIX] Keep localhost for the dev environment

### DIFF
--- a/paf-mvp-frontend/src/config/env__development.ts
+++ b/paf-mvp-frontend/src/config/env__development.ts
@@ -1,7 +1,7 @@
-import { cmpConfig, publisherConfig } from '../../../paf-mvp-demo-express/src/config';
+import { cmpConfig } from '../../../paf-mvp-demo-express/src/config';
 
 export const env = {
   isDevelopment: true,
-  host: `https://${publisherConfig.cdnHost}`,
+  host: 'http://localhost:3000',
   operatorProxyHost: cmpConfig.host,
 };


### PR DESCRIPTION
I use the "host" variable to build the absolute path for assets. In dev mode, everything is served on localhost.