### PR TITLE
[widget] "not participating" only on user action

### DIFF
--- a/paf-mvp-demo-express/src/cmp/js/cmp.ts
+++ b/paf-mvp-demo-express/src/cmp/js/cmp.ts
@@ -1,6 +1,13 @@
-import { refreshIdsAndPreferences, signPreferences, writeIdsAndPref } from '@frontend/lib/paf-lib';
+import {
+  refreshIdsAndPreferences,
+  removeCookie,
+  saveCookieValue,
+  signPreferences,
+  writeIdsAndPref
+} from '@frontend/lib/paf-lib';
 import { cmpConfig } from '../../config';
 import { PafStatus } from '@core/operator-client-commons';
+import { Cookies } from '@core/cookies';
 
 declare const PAF: {
   refreshIdsAndPreferences: typeof refreshIdsAndPreferences;
@@ -28,29 +35,42 @@ export const cmpCheck = async () => {
   const hasPersistedId = returnedId && returnedId.persisted !== false;
 
   if (!hasPersistedId || data.preferences === undefined) {
-    const optIn = await window.__promptConsent();
-    // 1. sign preferences
-    const unsignedPreferences = {
-      version: '0.1',
-      data: {
-        use_browsing_for_personalization: optIn,
-      },
-    };
-    const signedPreferences = await PAF.signPreferences(
-      { proxyHostName },
-      {
-        identifiers: data.identifiers,
-        unsignedPreferences,
-      }
-    );
+    // Reset cookies before to show the prompt to make sure we set the appropriate value only after user action
+    removeCookie(Cookies.identifiers);
+    removeCookie(Cookies.preferences);
 
-    // 2. write
-    await PAF.writeIdsAndPref(
-      { proxyHostName },
-      {
-        identifiers: data.identifiers,
-        preferences: signedPreferences,
-      }
-    );
+    const optIn = await window.__promptConsent();
+
+    if (optIn === undefined) {
+      // User closed the prompt consent without defining their preferences
+      // => means they are not participating
+      saveCookieValue(Cookies.identifiers, undefined);
+      saveCookieValue(Cookies.preferences, undefined);
+    } else {
+
+      // 1. sign preferences
+      const unsignedPreferences = {
+        version: '0.1',
+        data: {
+          use_browsing_for_personalization: optIn
+        }
+      };
+      const signedPreferences = await PAF.signPreferences(
+        { proxyHostName },
+        {
+          identifiers: data.identifiers,
+          unsignedPreferences
+        }
+      );
+
+      // 2. write
+      await PAF.writeIdsAndPref(
+        { proxyHostName },
+        {
+          identifiers: data.identifiers,
+          preferences: signedPreferences
+        }
+      );
+    }
   }
 };

--- a/paf-mvp-demo-express/src/cmp/js/cmp.ts
+++ b/paf-mvp-demo-express/src/cmp/js/cmp.ts
@@ -3,7 +3,7 @@ import {
   removeCookie,
   saveCookieValue,
   signPreferences,
-  writeIdsAndPref
+  writeIdsAndPref,
 } from '@frontend/lib/paf-lib';
 import { cmpConfig } from '../../config';
 import { PafStatus } from '@core/operator-client-commons';
@@ -47,19 +47,18 @@ export const cmpCheck = async () => {
       saveCookieValue(Cookies.identifiers, undefined);
       saveCookieValue(Cookies.preferences, undefined);
     } else {
-
       // 1. sign preferences
       const unsignedPreferences = {
         version: '0.1',
         data: {
-          use_browsing_for_personalization: optIn
-        }
+          use_browsing_for_personalization: optIn,
+        },
       };
       const signedPreferences = await PAF.signPreferences(
         { proxyHostName },
         {
           identifiers: data.identifiers,
-          unsignedPreferences
+          unsignedPreferences,
         }
       );
 
@@ -68,7 +67,7 @@ export const cmpCheck = async () => {
         { proxyHostName },
         {
           identifiers: data.identifiers,
-          preferences: signedPreferences
+          preferences: signedPreferences,
         }
       );
     }

--- a/paf-mvp-frontend/src/containers/welcome-widget/WelcomeWidget.tsx
+++ b/paf-mvp-frontend/src/containers/welcome-widget/WelcomeWidget.tsx
@@ -24,10 +24,9 @@ export interface IWelcomeWidgetProps {
   brandName?: string;
   brandLogoUrl?: string;
   emitConsent?: (value: boolean) => void;
-  destroy?: () => void;
 }
 
-export const WelcomeWidget = ({ emitConsent, destroy }: IWelcomeWidgetProps) => {
+export const WelcomeWidget = ({ emitConsent }: IWelcomeWidgetProps) => {
   const [isOpen, setIsOpen] = useState(true);
   const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false);
   const [pafCookies, setPafCookies] = useState(window.PAF.getIdsAndPreferences());
@@ -54,7 +53,7 @@ export const WelcomeWidget = ({ emitConsent, destroy }: IWelcomeWidgetProps) => 
 
   const closeWidget = () => {
     setIsOpen(false);
-    destroy();
+    emitConsent(undefined);
   };
 
   const updateIdentifier = async () => {

--- a/paf-mvp-frontend/src/lib/paf-lib.ts
+++ b/paf-mvp-frontend/src/lib/paf-lib.ts
@@ -54,8 +54,12 @@ const removeUrlParameter = (url: string, parameter: string) => {
   return url;
 };
 
-const setCookie = (name: string, value: string, expiration: Date) => {
-  document.cookie = `${name}=${value};expires=${expiration.toUTCString()}`;
+const setCookie = (cookieName: string, value: string, expiration: Date) => {
+  document.cookie = `${cookieName}=${value};expires=${expiration.toUTCString()}`;
+};
+
+export const removeCookie = (cookieName: string) => {
+  setCookie(cookieName, null, new Date(0));
 };
 
 // Update the URL shown in the address bar, without PAF data
@@ -66,8 +70,8 @@ const getProxyUrl =
   (endpoint: string): string =>
     `https://${proxyHost}${endpoint}`;
 
-const saveCookieValue = <T>(cookieName: string, cookieValue: T | undefined): string => {
-  logger.info(`Operator returned value for ${cookieName}: ${cookieValue !== undefined ? 'YES' : 'NO'}`);
+export const saveCookieValue = <T>(cookieName: string, cookieValue: T | undefined): string => {
+  logger.info(`Value for ${cookieName}: ${cookieValue !== undefined ? 'YES' : 'NO'}`);
 
   const valueToStore = cookieValue === undefined ? PafStatus.NOT_PARTICIPATING : JSON.stringify(cookieValue);
 
@@ -77,10 +81,6 @@ const saveCookieValue = <T>(cookieName: string, cookieValue: T | undefined): str
   setCookie(cookieName, valueToStore, getPrebidDataCacheExpiration());
 
   return valueToStore;
-};
-
-const removeCookie = (cookieName: string) => {
-  setCookie(cookieName, null, new Date(0));
 };
 
 let thirdPartyCookiesSupported: boolean | undefined;

--- a/paf-mvp-frontend/src/widgets/prompt-consent.ts
+++ b/paf-mvp-frontend/src/widgets/prompt-consent.ts
@@ -7,10 +7,6 @@ export class PromptConsent extends BasePafWidget<IWelcomeWidgetProps> {
       this.remove();
       props.emitConsent(value);
     };
-    const destroy = () => {
-      this.remove();
-      props.destroy?.();
-    };
-    super(WelcomeWidget, { ...props, emitConsent, destroy });
+    super(WelcomeWidget, { ...props, emitConsent });
   }
 }


### PR DESCRIPTION
Publisher: do not consider the user is "not participating" until they closed the widget.
As long as the user didn't interract with the widget, it will be displayed (even after a refresh)